### PR TITLE
[DENG-4544] - Add timeline server port fix to hudi fork - forked off datalake branch

### DIFF
--- a/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/TimelineService.java
+++ b/hudi-timeline-service/src/main/java/org/apache/hudi/timeline/service/TimelineService.java
@@ -33,6 +33,7 @@ import org.apache.hudi.storage.StorageConfiguration;
 import com.beust.jcommander.JCommander;
 import com.beust.jcommander.Parameter;
 import io.javalin.Javalin;
+import io.javalin.core.util.JavalinBindException;
 import org.apache.hadoop.conf.Configuration;
 import org.eclipse.jetty.server.Server;
 import org.eclipse.jetty.util.thread.QueuedThreadPool;
@@ -325,18 +326,19 @@ public class TimelineService {
       // Returns port to try when trying to bind a service. Handles wrapping and skipping privileged ports.
       int tryPort = port == 0 ? port : (port + attempt - 1024) % (65536 - 1024) + 1024;
       try {
+        createApp();
         app.start(tryPort);
         return app.port();
       } catch (Exception e) {
-        if (e.getMessage() != null && e.getMessage().contains("Failed to bind to")) {
+        if (e instanceof JavalinBindException) {
           if (tryPort == 0) {
-            LOG.warn("Timeline server could not bind on a random free port.");
+            LOG.warn("Timeline server could not bind on port {}. Attempting port {} + 1.", tryPort, tryPort);
           } else {
             LOG.warn(String.format("Timeline server could not bind on port %d. "
                 + "Attempting port %d + 1.",tryPort, tryPort));
           }
         } else {
-          LOG.warn(String.format("Timeline server start failed on port %d. Attempting port %d + 1.",tryPort, tryPort), e);
+          LOG.warn("Timeline server start failed on port {}. Attempting port {} + 1.", tryPort, tryPort, e);
         }
       }
     }
@@ -344,6 +346,17 @@ public class TimelineService {
   }
 
   public int startService() throws IOException {
+    int realServerPort = startServiceOnPort(serverPort);
+    LOG.info("Starting Timeline server on port: {}", realServerPort);
+    this.serverPort = realServerPort;
+    return realServerPort;
+  }
+
+  private void createApp() throws IOException {
+    // if app needs to be recreated, stop the existing one
+    if (app != null) {
+      app.stop();
+    }
     int maxThreads = timelineServerConf.numThreads > 0 ? timelineServerConf.numThreads : DEFAULT_NUM_THREADS;
     QueuedThreadPool pool = new QueuedThreadPool(maxThreads, 8, 60_000);
     pool.setDaemon(true);
@@ -362,10 +375,6 @@ public class TimelineService {
         app, conf, timelineServerConf, context, storage, fsViewsManager);
     app.get("/", ctx -> ctx.result("Hello Hudi"));
     requestHandler.register();
-    int realServerPort = startServiceOnPort(serverPort);
-    LOG.info("Starting Timeline server on port :" + realServerPort);
-    this.serverPort = realServerPort;
-    return realServerPort;
   }
 
   public void run() throws IOException {


### PR DESCRIPTION
### Change Logs

We've been seeing recurring issues with the timeline server being unable to bind a port when running hudi streamer jobs.
This PR copies the changes found in this PR against the main Hudi repo. Please see the change here: https://github.com/apache/hudi/pull/12241/files

Please note that the unit tests created here were not copied because they reference packages that do not exist in our version of Hudi.

Changelog notes from original PR:
- If the specified port is in use, there is no way for the server to start currently due to a bug in the logic for trying a new port. This PR updates the logic to work properly and adds a test (again, please note, we do not add the unit test here for above reason mentioned)

### Impact

Introduces changes from this PR that should help resolve the port retry issue: https://github.com/apache/hudi/pull/12241/files.

Impact noted on the PR is: `Fixes existing bug in timeline server code`

### Risk level (write none, low medium or high below)

Low. If this does not succeed in a lower environment, we can simply revert this change. Additionally, we can also revert it in prod using our regular release/revert process.

### Documentation Update

_Describe any necessary documentation update if there is any new feature, config, or user-facing change. If not, put "none"._

- _The config description must be updated if new configs are added or the default value of the configs are changed_
- _Any new feature or user-facing change requires updating the Hudi website. Please create a Jira ticket, attach the
  ticket number here and follow the [instruction](https://hudi.apache.org/contribute/developer-setup#website) to make
  changes to the website._

### Contributor's checklist

- [ ] Read through [contributor's guide](https://hudi.apache.org/contribute/how-to-contribute)
- [ ] Change Logs and Impact were stated clearly
- [ ] Adequate tests were added if applicable
- [ ] CI passed
