### PR TITLE
Merge Datalake Changes into Hudi 1.0.2

### DIFF
--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/HoodieAsyncService.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/async/HoodieAsyncService.java
@@ -123,7 +123,7 @@ public abstract class HoodieAsyncService implements Serializable {
           executor.shutdown();
           try {
             // Wait for some max time after requesting shutdown
-            executor.awaitTermination(24, TimeUnit.HOURS);
+            executor.awaitTermination(10, TimeUnit.SECONDS);
           } catch (InterruptedException ie) {
             LOG.error("Interrupted while waiting for shutdown", ie);
           }

--- a/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/WriteStatus.java
+++ b/hudi-client/hudi-client-common/src/main/java/org/apache/hudi/client/WriteStatus.java
@@ -155,6 +155,7 @@ public class WriteStatus implements Serializable {
     if (failedRecords.isEmpty() || (random.nextDouble() <= failureFraction)) {
       // Guaranteed to have at-least one error
       failedRecords.add(Pair.of(HoodieRecordDelegate.fromHoodieRecord(record), t));
+      LOG.info("Found error in record " + record.getKey() + " in WriteStatus.java: " + t);
       errors.put(record.getKey(), t);
     }
     updateStatsForFailure();

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/debezium/DebeziumSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/debezium/DebeziumSource.java
@@ -126,6 +126,10 @@ public abstract class DebeziumSource extends RowSource {
     try {
       String schemaStr = schemaRegistryProvider.fetchSchemaFromRegistry(getStringWithAltKeys(props, HoodieSchemaProviderConfig.SRC_SCHEMA_REGISTRY_URL));
       Dataset<Row> dataset = toDataset(offsetRanges, offsetGen, schemaStr);
+      if (dataset.count() == 0) {
+          LOG.info("After filtering for null value messages, dataframe size is empty");
+          return Pair.of(Option.of(sparkSession.emptyDataFrame()),new StreamerCheckpointV2(overrideCheckpointStr.isEmpty() ? CheckpointUtils.offsetsToStr(offsetRanges) : overrideCheckpointStr));
+        }
       LOG.info(String.format("Spark schema of Kafka Payload for topic %s:\n%s", offsetGen.getTopicName(), dataset.schema().treeString()));
       LOG.info(String.format("New checkpoint string: %s", CheckpointUtils.offsetsToStr(offsetRanges)));
       return Pair.of(Option.of(dataset),
@@ -156,6 +160,7 @@ public abstract class DebeziumSource extends RowSource {
     if (deserializerClassName.equals(StringDeserializer.class.getName())) {
       kafkaData = AvroConversionUtils.createDataFrame(
           KafkaUtils.<String, String>createRDD(sparkContext, offsetGen.getKafkaParams(), offsetRanges, LocationStrategies.PreferConsistent())
+              .filter(x -> filterForNullValues(x.value()))
               .map(obj -> convertor.fromJson(obj.value()))
               .rdd(), schemaStr, sparkSession);
     } else {
@@ -171,6 +176,14 @@ public abstract class DebeziumSource extends RowSource {
     // Some required transformations to ensure debezium data types are converted to spark supported types.
     return convertArrayColumnsToString(convertColumnToNullable(sparkSession,
         convertDateColumns(debeziumDataset, new Schema.Parser().parse(schemaStr))));
+  }
+
+  private static Boolean filterForNullValues(Object value) {
+    if (value == null) {
+      LOG.info("Found a null value (tombstone) message, filtering it out of the dataframe.");
+      return false;
+    }
+    return true;
   }
 
   /**

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/debezium/DebeziumSource.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/sources/debezium/DebeziumSource.java
@@ -127,9 +127,9 @@ public abstract class DebeziumSource extends RowSource {
       String schemaStr = schemaRegistryProvider.fetchSchemaFromRegistry(getStringWithAltKeys(props, HoodieSchemaProviderConfig.SRC_SCHEMA_REGISTRY_URL));
       Dataset<Row> dataset = toDataset(offsetRanges, offsetGen, schemaStr);
       if (dataset.count() == 0) {
-          LOG.info("After filtering for null value messages, dataframe size is empty");
-          return Pair.of(Option.of(sparkSession.emptyDataFrame()),new StreamerCheckpointV2(overrideCheckpointStr.isEmpty() ? CheckpointUtils.offsetsToStr(offsetRanges) : overrideCheckpointStr));
-        }
+        LOG.info("After filtering for null value messages, dataframe size is empty");
+        return Pair.of(Option.of(sparkSession.emptyDataFrame()),new StreamerCheckpointV2(overrideCheckpointStr.isEmpty() ? CheckpointUtils.offsetsToStr(offsetRanges) : overrideCheckpointStr));
+      }
       LOG.info(String.format("Spark schema of Kafka Payload for topic %s:\n%s", offsetGen.getTopicName(), dataset.schema().treeString()));
       LOG.info(String.format("New checkpoint string: %s", CheckpointUtils.offsetsToStr(offsetRanges)));
       return Pair.of(Option.of(dataset),

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/HoodieStreamer.java
@@ -862,6 +862,7 @@ public class HoodieStreamer implements Serializable {
                 LOG.warn("Closing and shutting down ingestion service");
                 error = true;
                 onIngestionCompletes(false);
+                shutdownAsyncServices(error);
                 shutdown(true);
               } else {
                 sleepBeforeNextIngestion(start);

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/streamer/StreamSync.java
@@ -884,7 +884,7 @@ public class StreamSync implements Serializable, Closeable {
         dataTableWriteStatusRDD.filter(WriteStatus::hasErrors).take(100).forEach(ws -> {
           LOG.error("Global error :", ws.getGlobalError());
           if (ws.getErrors().size() > 0) {
-            ws.getErrors().forEach((key, value) -> LOG.trace("Error for key:" + key + " is " + value));
+            ws.getErrors().forEach((key, value) -> LOG.info("Error for key:" + key + " is " + value));
           }
         });
         // Rolling back instant

--- a/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/SqlQueryBasedTransformer.java
+++ b/hudi-utilities/src/main/java/org/apache/hudi/utilities/transform/SqlQueryBasedTransformer.java
@@ -30,6 +30,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.apache.hudi.common.util.ConfigUtils.getStringWithAltKeys;
 
@@ -50,6 +52,29 @@ public class SqlQueryBasedTransformer implements Transformer {
       TypedProperties properties) {
     String transformerSQL = getStringWithAltKeys(properties, SqlTransformerConfig.TRANSFORMER_SQL);
 
+    if (rowDataset.schema().length() == 0) {
+      LOG.info("rowDataset does not have schema, skipping SQL Transformer");
+      return rowDataset;
+    }
+
+    // Extract except clause into formattedColumns if found
+    Pattern pattern = Pattern.compile("(?i)(.*\\*) except\\(([^)]*)\\)(.*)");
+    Matcher matcher = pattern.matcher(transformerSQL);
+    String[] formattedColumns = {};
+    boolean dropColumns = false;
+    if (matcher.find()) {
+      String columnString = matcher.group(2);
+      String[] columns = columnString.split(",", 0);
+      formattedColumns = new String[columns.length];
+      for (int i = 0; i < columns.length; i++) {
+        formattedColumns[i] = columns[i].trim();
+      }
+      LOG.info("Found 'except' clause in SQL query transform for columns: " + String.join(", ", formattedColumns));
+      dropColumns = true;
+      transformerSQL = matcher.group(1) + matcher.group(3);
+      LOG.info("Generated new SQL query transform: " + transformerSQL);
+    }
+
     try {
       // tmp table name doesn't like dashes
       String tmpTable = TMP_TABLE.concat(UUID.randomUUID().toString().replace("-", "_"));
@@ -59,6 +84,12 @@ public class SqlQueryBasedTransformer implements Transformer {
       LOG.debug("SQL Query for transformation: {}", sqlStr);
       Dataset<Row> transformed = sparkSession.sql(sqlStr);
       sparkSession.catalog().dropTempView(tmpTable);
+      if (dropColumns) {
+        LOG.info("Dropping columns: " + String.join(", ", formattedColumns));
+        for (String column : formattedColumns) {
+          transformed = transformed.drop(column);
+        }
+      }
       return transformed;
     } catch (Exception e) {
       throw new HoodieTransformExecutionException("Failed to apply sql query based transformer", e);


### PR DESCRIPTION
Description:

This PR takes all of the changes we have historically made to the Hudi library on the Datalake branch:

- Change termination from 24 hours to 10 seconds
- Filter Null Values/Tombstones
- Ability to exclude columns on transformer sql. 
- Shutdown async services on error. 
- Skip Transformer SQL on null dataset. 